### PR TITLE
Switch from node-webcrypto-ossl to @peculiar/webcrypto from davedoesdev/fido2-lib fork

### DIFF
--- a/lib/certUtils.js
+++ b/lib/certUtils.js
@@ -2,7 +2,7 @@
 
 const asn1js = require("asn1js");
 const pkijs = require("pkijs");
-const WebCrypto = require("node-webcrypto-ossl");
+const WebCrypto = require("@peculiar/webcrypto").Crypto;
 const webcrypto = new WebCrypto();
 
 const {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "cose-to-jwk": "^1.1.0",
     "jwk-to-pem": "^2.0.0",
     "node-jose": "^1.0.0",
-    "node-webcrypto-ossl": "^1.0.35",
+    "@peculiar/webcrypto": "^1.0.1",
     "pkijs": "=2.1.58",
     "psl": "^1.1.24"
   }


### PR DESCRIPTION
Due to https://github.com/PeculiarVentures/node-webcrypto-ossl/issues/138

@peculiar/webcrypto is the replacement which doesn't need C code
(uses Node crypto from JS only).